### PR TITLE
fix sajson_wrapper.h compile error; Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+# modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml
+name: CI tests
+
+on:
+  push:
+    branches:
+    - '*'
+    paths-ignore: []
+  pull_request:
+    paths-ignore: []
+
+jobs:
+  linux:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        versions:
+          - ghc: '8.6.5'
+            cabal: '3.2'
+          - ghc: '8.8.4'
+            cabal: '3.2'
+          - ghc: '8.10.3'
+            cabal: '3.2'
+          - ghc: '8.6.5'
+            cabal: '3.4'
+          - ghc: '8.8.4'
+            cabal: '3.4'
+          - ghc: '8.10.3'
+            cabal: '3.4'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install recent cabal/ghc
+      uses: actions/setup-haskell@v1.1.3
+      with:
+        ghc-version: ${{ matrix.versions.ghc }}
+        cabal-version: ${{ matrix.versions.cabal }}
+
+    - name: Cache cabal global package db
+      id:   cabal-global
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-global-${{ hashFiles('cabal.project') }}
+
+    - name: Cache cabal work
+      id:   cabal-local
+      uses: actions/cache@v2
+      with:
+        path: |
+          dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.versions.ghc }}-${{ matrix.versions.cabal }}-cabal-local
+
+    - name: Install dependencies
+      run: |
+          cabal update
+          cabal build --dependencies-only --enable-tests --disable-optimization
+    - name: Build
+      run: |
+          cabal build --enable-tests --disable-optimization 2>&1 | tee build.log
+    - name: Test
+      run: |
+          cabal test --disable-optimization

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/sajson.cabal
+++ b/sajson.cabal
@@ -30,6 +30,8 @@ library
   default-language:    Haskell2010
   include-dirs:        cbits
   c-sources:           cbits/sajson_wrapper.cpp
+                     , cbits/sajson_wrapper.h
+  install-includes:    cbits/sajson.hpp
   cc-options:          -Wall -O3 -march=native -std=c++11 -fomit-frame-pointer
   ghc-options:         -Wall -O2
   extra-libraries:     stdc++


### PR DESCRIPTION
I believe this solves https://github.com/kccqzy/haskell-sajson/issues/1

The error had only occurred for me in a dependent project while using Cabal 3.4

Github Actions modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml